### PR TITLE
Changed mb_strlen() to strlen() for file size calculation

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -200,7 +200,7 @@ class Client
         } else {
             // We've been given a simple string body, it's super simple to calculate the hash and size.
             $hash = sha1($options['Body']);
-            $size = mb_strlen($options['Body']);
+            $size = strlen($options['Body']);
         }
 
         if (!isset($options['FileLastModified'])) {


### PR DESCRIPTION
The file size was being calculated using multibyte characters rather than bytes, which resulted in rejected uploads due to a hash mismatch.