### PR TITLE
application key support addon

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -409,7 +409,8 @@ class Client
         $response = $this->client->request('GET', self::B2_API_BASE_URL.self::B2_API_V1.'/b2_authorize_account', [
             'auth' => [$this->accountId, $this->applicationKey],
         ]);
-
+        
+        $this->accountId = $response['accountId'];
         $this->authToken = $response['authorizationToken'];
         $this->apiUrl = $response['apiUrl'].self::B2_API_V1;
         $this->downloadUrl = $response['downloadUrl'];
@@ -649,6 +650,11 @@ class Client
     protected function sendAuthorizedRequest($method, $route, $json = [])
     {
         $this->authorizeAccount();
+
+        //overwriting the accountID with master account ID after authentification
+        if (isset($json['accountId'])) {
+            $json['accountId'] = $this->accountId;
+        }
 
         return $this->client->request($method, $this->apiUrl.$route, [
             'headers' => [


### PR DESCRIPTION
It seems that application key support integration is pretty simple, after normal authorisation, the B2 Api sends back the main accountId in the response header which we can use for the rest of the API requests that require the master account ID to be present, like the listBuckets api call.

Could you review this and let me know if we can integrated this inside the main package?