### PR TITLE
Harmonize & document exceptions

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 
 namespace BackblazeB2;
 
+use BackblazeB2\Exceptions\B2Exception;
 use BackblazeB2\Exceptions\NotFoundException;
 use BackblazeB2\Exceptions\ValidationException;
 use BackblazeB2\Http\Client as HttpClient;
@@ -57,6 +58,9 @@ class Client
      * @throws ValidationException
      *
      * @return Bucket
+     *
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      */
     public function createBucket(array $options)
     {
@@ -83,6 +87,9 @@ class Client
      * @throws ValidationException
      *
      * @return Bucket
+     *
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      */
     public function updateBucket(array $options)
     {
@@ -109,6 +116,9 @@ class Client
      * Returns a list of bucket objects representing the buckets on the account.
      *
      * @return array
+     *
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      */
     public function listBuckets()
     {
@@ -131,6 +141,9 @@ class Client
      * @param array $options
      *
      * @return bool
+     *
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      */
     public function deleteBucket(array $options)
     {
@@ -152,6 +165,9 @@ class Client
      * @param array $options
      *
      * @return File
+     *
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      */
     public function upload(array $options)
     {
@@ -261,6 +277,9 @@ class Client
      * @param array $options
      *
      * @return array
+     *
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      */
     public function listFiles(array $options)
     {
@@ -337,6 +356,9 @@ class Client
      * @throws NotFoundException If no file id was provided and BucketName + FileName does not resolve to a file, a NotFoundException is thrown.
      *
      * @return File
+     *
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      */
     public function getFile(array $options)
     {
@@ -374,6 +396,9 @@ class Client
      * @throws NotFoundException
      *
      * @return bool
+     *
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      */
     public function deleteFile(array $options)
     {
@@ -528,6 +553,9 @@ class Client
      * @param $bucketId
      *
      * @return mixed
+     *
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      */
     protected function startLargeFile($fileName, $contentType, $bucketId)
     {
@@ -544,6 +572,9 @@ class Client
      * @param $fileId
      *
      * @return mixed
+     *
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      */
     protected function getUploadPartUrl($fileId)
     {
@@ -616,6 +647,9 @@ class Client
      * @param array $sha1s
      *
      * @return File
+     *
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      */
     protected function finishLargeFile($fileId, array $sha1s)
     {
@@ -645,6 +679,9 @@ class Client
      * @param array  $json
      *
      * @return mixed
+     *
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      */
     protected function sendAuthorizedRequest($method, $route, $json = [])
     {

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -24,6 +24,11 @@ class ErrorHandler
         'unauthorized'                   => UnauthorizedAccessException::class,
     ];
 
+    /**
+     * @param Response $response
+     *
+     * @throws B2Exception
+     */
     public static function handleErrorResponse(Response $response)
     {
         $responseJson = json_decode($response->getBody(), true);

--- a/src/Exceptions/BadJsonException.php
+++ b/src/Exceptions/BadJsonException.php
@@ -2,6 +2,6 @@
 
 namespace BackblazeB2\Exceptions;
 
-class BadJsonException extends \Exception
+class BadJsonException extends B2Exception
 {
 }

--- a/src/Exceptions/BadValueException.php
+++ b/src/Exceptions/BadValueException.php
@@ -2,6 +2,6 @@
 
 namespace BackblazeB2\Exceptions;
 
-class BadValueException extends \Exception
+class BadValueException extends B2Exception
 {
 }

--- a/src/Exceptions/BucketAlreadyExistsException.php
+++ b/src/Exceptions/BucketAlreadyExistsException.php
@@ -2,6 +2,6 @@
 
 namespace BackblazeB2\Exceptions;
 
-class BucketAlreadyExistsException extends \Exception
+class BucketAlreadyExistsException extends B2Exception
 {
 }

--- a/src/Exceptions/BucketNotEmptyException.php
+++ b/src/Exceptions/BucketNotEmptyException.php
@@ -2,6 +2,6 @@
 
 namespace BackblazeB2\Exceptions;
 
-class BucketNotEmptyException extends \Exception
+class BucketNotEmptyException extends B2Exception
 {
 }

--- a/src/Exceptions/FileNotPresentException.php
+++ b/src/Exceptions/FileNotPresentException.php
@@ -2,6 +2,6 @@
 
 namespace BackblazeB2\Exceptions;
 
-class FileNotPresentException extends \Exception
+class FileNotPresentException extends B2Exception
 {
 }

--- a/src/Exceptions/NotFoundException.php
+++ b/src/Exceptions/NotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace BackblazeB2\Exceptions;
 
-class NotFoundException extends \Exception
+class NotFoundException extends B2Exception
 {
 }

--- a/src/Exceptions/UnauthorizedAccessException.php
+++ b/src/Exceptions/UnauthorizedAccessException.php
@@ -2,6 +2,6 @@
 
 namespace BackblazeB2\Exceptions;
 
-class UnauthorizedAccessException extends \Exception
+class UnauthorizedAccessException extends B2Exception
 {
 }

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -2,6 +2,6 @@
 
 namespace BackblazeB2\Exceptions;
 
-class ValidationException extends \Exception
+class ValidationException extends B2Exception
 {
 }

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -3,6 +3,7 @@
 namespace BackblazeB2\Http;
 
 use BackblazeB2\ErrorHandler;
+use BackblazeB2\Exceptions\B2Exception;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Http\Message\ResponseInterface;
@@ -20,7 +21,8 @@ class Client extends GuzzleClient
      * @param array  $options
      * @param bool   $asJson
      *
-     * @throws GuzzleException
+     * @throws GuzzleException If the request fails.
+     * @throws B2Exception     If the B2 server replies with an error.
      *
      * @return mixed|ResponseInterface|string
      */


### PR DESCRIPTION
Implementation of the suggestions in #45:

- all `BackblazeB2\Exceptions\*` exceptions now extend the generic `B2Exception`
- all `Client` methods are now documented to either throw:
    - a `GuzzleException` if the request fails
    - a `B2Exception` if the B2 server replies with an error

No BC breaks! 👍 