### PR TITLE
Guzzle 7 Interface Fix

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -212,7 +212,7 @@ class Client
             $options['FileContentType'] = 'b2/x-auto';
         }
 
-        $response = $this->client->request('POST', $uploadEndpoint, [
+        $response = $this->client->guzzleRequest('POST', $uploadEndpoint, [
             'headers' => [
                 'Authorization'                      => $uploadAuthToken,
                 'Content-Type'                       => $options['FileContentType'],
@@ -264,7 +264,7 @@ class Client
 
         $this->authorizeAccount();
 
-        $response = $this->client->request('GET', $requestUrl, $requestOptions, false);
+        $response = $this->client->guzzleRequest('GET', $requestUrl, $requestOptions, false);
 
         return isset($options['SaveAs']) ? true : $response;
     }
@@ -427,7 +427,7 @@ class Client
             return;
         }
 
-        $response = $this->client->request('GET', self::B2_API_BASE_URL.self::B2_API_V1.'/b2_authorize_account', [
+        $response = $this->client->guzzleRequest('GET', self::B2_API_BASE_URL.self::B2_API_V1.'/b2_authorize_account', [
             'auth' => [$this->accountId, $this->applicationKey],
         ]);
 
@@ -614,7 +614,7 @@ class Client
             array_push($sha1_of_parts, sha1($data_part));
             fseek($file_handle, $total_bytes_sent);
 
-            $response = $this->client->request('POST', $uploadUrl, [
+            $response = $this->client->guzzleRequest('POST', $uploadUrl, [
                 'headers' => [
                     'Authorization'                      => $largeFileAuthToken,
                     'Content-Length'                     => $bytes_sent_for_part,
@@ -683,7 +683,7 @@ class Client
     {
         $this->authorizeAccount();
 
-        return $this->client->request($method, $this->apiUrl.$route, [
+        return $this->client->guzzleRequest($method, $this->apiUrl.$route, [
             'headers' => [
                 'Authorization' => $this->authToken,
             ],

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -26,7 +26,7 @@ class Client extends GuzzleClient
      *
      * @return mixed|ResponseInterface|string
      */
-    public function request($method, $uri = null, array $options = [], $asJson = true)
+    public function guzzleRequest($method, $uri = null, array $options = [], $asJson = true)
     {
         $response = parent::request($method, $uri, $options);
 


### PR DESCRIPTION
Fix for #53 

Was two options for this problem

1. Rewrite the codebase to no longer need the `asJson` variable in request
2. Just keep the existing Request format but make it so the Interfaces don't conflict.

Went with 2 to keep things simple for now. I'd like to do a bigger re-write of this in the near future to support the B2 V2 API in the next few months.