### PR TITLE
Implement copying files

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ $fileContent = $client->download([
 ]);
 ```
 
+#### File Copy
+``` php
+$copyOfFile = $client->copy([
+    'BucketName' => $bucketName,
+    'FileName'   => $path,
+    'SaveAs'     => $newPath,
+
+    // Can also supply BucketId instead of BucketName
+    // Optional are DestinationBucketName or DestinationBucketId
+]);
+```
+
 #### File Delete
 ``` php
 $fileDelete = $client->deleteFile([

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -489,6 +489,26 @@ class ClientTest extends TestCase
         ]);
     }
 
+    public function testCopyFile()
+    {
+        $guzzle = $this->buildGuzzleFromResponses([
+            $this->buildResponseFromStub(200, [], 'authorize_account.json'),
+            $this->buildResponseFromStub(200, [], 'list_files_page1.json'),
+            $this->buildResponseFromStub(200, [], 'copy_file.json'),
+        ]);
+
+        $client = new Client('testId', 'testKey', ['client' => $guzzle]);
+
+        $actual = $client->copy([
+            'BucketId' => 'sourceBucketId',
+            'FileName' => 'sourceFileName',
+            'SaveAs'   => 'destinationFileName',
+        ]);
+
+        $this->assertInstanceOf('BackblazeB2\File', $actual);
+        $this->assertEquals('4_z4c2b953461da9c825f260e1b_f1114dbf5bg9707e8_d20160206_m012226_c001_v1111017_t0010', $actual->getId());
+    }
+
     public function testDeleteFile()
     {
         $guzzle = $this->buildGuzzleFromResponses([

--- a/tests/responses/copy_file.json
+++ b/tests/responses/copy_file.json
@@ -1,0 +1,14 @@
+{
+  "accountId": "accountId",
+  "bucketId": "bucketId",
+  "contentLength": 20,
+  "contentSha1": "bc77b0349d325be71ed2ca26d5e68173210e9e18",
+  "contentType": "application/octet-stream",
+  "fileId": "4_z4c2b953461da9c825f260e1b_f1114dbf5bg9707e8_d20160206_m012226_c001_v1111017_t0010",
+  "fileInfo": {
+    "src_last_modified_millis": "1454721688784"
+  },
+  "action": "upload",
+  "uploadTimestamp": "1465983870000",
+  "fileName": "Test file.bin"
+}

--- a/tests/responses/list_files_single.json
+++ b/tests/responses/list_files_single.json
@@ -1,0 +1,18 @@
+{
+  "files": [
+    {
+      "accountId": "accountId",
+      "bucketId": "bucketId",
+      "contentLength": 20,
+      "contentSha1": "bc77b0349d325be71ed2ca26d5e68173210e9e18",
+      "contentType": "application/octet-stream",
+      "fileId": "4_z4c2b953461da9c825f260e1b_f1114dbf5bg9707e8_d20160206_m012226_c001_v1111017_t0010",
+      "fileInfo": {
+        "src_last_modified_millis": "1454721688784"
+      },
+      "action": "upload",
+      "uploadTimestamp": "1465983870000",
+      "fileName": "Test file.bin"
+    }
+  ]
+}


### PR DESCRIPTION
The b2 API supports copying files through the endpoint b2_copy_file.

The options array supports BucketName or BucketId, FileName, SaveAs, and
optionally destinationBucketId or destinationBucketName.

As a bonus, there is now getFileIdFromBucketIdAndFileName, a faster
way to retrieve FileIds for single files.