### PR TITLE
PHP 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,8 @@ language: php
 
 php:
   - '7.2'
+  - '7.3'
+  - '7.4'
+  - '8.0'
 
 before_script: composer install

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.1|^7.0",
         "nesbot/carbon": "2.*"


### PR DESCRIPTION
The current `composer.json` is not compatible with PHP 8.

I added tests for PHP 8 on Travis, + missing supported PHP versions, 7.3 & 7.4.