### PR TITLE
Allow fetching file by bucket id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 coverage
 coverage.xml
 .idea/
+.phpunit.result.cache

--- a/src/Client.php
+++ b/src/Client.php
@@ -11,8 +11,8 @@ use GuzzleHttp\Exception\GuzzleException;
 
 class Client
 {
-    private const B2_API_BASE_URL = 'https://api.backblazeb2.com';
-    private const B2_API_V1 = '/b2api/v1/';
+    const B2_API_BASE_URL = 'https://api.backblazeb2.com';
+    const B2_API_V1 = '/b2api/v1/';
     protected $accountId;
     protected $applicationKey;
     protected $authToken;
@@ -359,7 +359,18 @@ class Client
      */
     public function getFile(array $options)
     {
-        if (!isset($options['FileId']) && isset($options['BucketName']) && isset($options['FileName'])) {
+        if (!isset($options['FileId']) && isset($options['BucketId']) && isset($options['FileName'])) {
+            $files = $this->listFiles([
+                'BucketId' => $options['BucketId'],
+                'FileName' => $options['FileName'],
+            ]);
+
+            if (empty($files)) {
+                throw new NotFoundException();
+            }
+
+            $options['FileId'] = $files[0]->getId();
+        } elseif (!isset($options['FileId']) && isset($options['BucketName']) && isset($options['FileName'])) {
             $options['FileId'] = $this->getFileIdFromBucketAndFileName($options['BucketName'], $options['FileName']);
 
             if (!$options['FileId']) {


### PR DESCRIPTION
## Description
Please see https://github.com/gliterd/flysystem-backblaze/pull/24 for the full description and reasoning behind this change.

To summarise, once the backblaze adapter can be configured with both bucket id and name, we will no longer need to use master keys to integrate with backblaze, and can use application keys which give access to a single bucket.

The function `listFiles` prefers to receive a `BucketId`. If given only a `BucketName`, it will attempt to look up the id. But this lookup requires a call to `list_buckets` which requires the master key.

This PR makes it so that if `getFile` is called with a bucket id (or both bucket id and name) then it will not attempt to look up the bucket id.