### PR TITLE
Always fill the File object with all available response data

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -231,7 +231,10 @@ class Client
             $response['contentSha1'],
             $response['contentLength'],
             $response['contentType'],
-            $response['fileInfo']
+            $response['fileInfo'],
+            $response['bucketId'],
+            $response['action'],
+            $response['uploadTimestamp']
         );
     }
 
@@ -380,7 +383,7 @@ class Client
             foreach ($response['files'] as $file) {
                 // if we have a file name set, only retrieve information if the file name matches
                 if (!$fileName || ($fileName === $file['fileName'])) {
-                    $files[] = new File($file['fileId'], $file['fileName'], null, $file['size']);
+                    $files[] = new File($file['fileId'], $file['fileName'], $file['contentSha1'], $file['size'], $file['contentType'], $file['fileInfo'], $file['bucketId'], $file['action'], $file['uploadTimestamp']);
                 }
             }
 

--- a/tests/responses/list_files_page1.json
+++ b/tests/responses/list_files_page1.json
@@ -2,6902 +2,12902 @@
   "files": [
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "sourceFileName",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     }

--- a/tests/responses/list_files_page2.json
+++ b/tests/responses/list_files_page2.json
@@ -2,3452 +2,6452 @@
   "files": [
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },{
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
-      "size": 140827,
-      "uploadTimestamp": 1454256286000
-    },
-    {
-      "action": "upload",
-      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
-      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },{
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     },
     {
       "action": "upload",
+      "bucketId": "bucketId",
       "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
       "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },{
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
+      "size": 140827,
+      "uploadTimestamp": 1454256286000
+    },
+    {
+      "action": "upload",
+      "bucketId": "bucketId",
+      "fileId": "4_z4c2b957661hy9c825f260e1b_f115af4dca081b246_d20160131_m160446_f001_v0011017_t0002",
+      "fileName": "testfile.bin",
+      "fileInfo": {
+        "src_last_modified_millis": "1453326047773"
+      },
+      "contentSha1": "a2995230e2ef0efe74efb014db7a2b0a9aa34f30",
+      "contentType": "application/octet-stream",
       "size": 140827,
       "uploadTimestamp": 1454256286000
     }

--- a/tests/responses/upload.json
+++ b/tests/responses/upload.json
@@ -1,12 +1,30 @@
 {
   "accountId": "accountId",
+  "action": "upload",
   "bucketId": "bucketId",
   "contentLength": 555,
+  "contentMd5": "cf9ca72110db83d49fc0b1cb248fb2dc",
   "contentSha1": "0f4dd743cc9c501c70b6e3d2e033e179926ee768",
   "contentType": "application/octet-stream",
   "fileId": "fileId",
   "fileInfo": {
     "src_last_modified_millis": "1453326047773"
   },
-  "fileName": "testfile.bin"
+  "fileName": "testfile.bin",
+  "fileRetention": {
+    "isClientAuthorizedToRead": true,
+    "value": {
+      "mode": null,
+      "retainUntilTimestamp": null
+    }
+  },
+  "legalHold": {
+    "isClientAuthorizedToRead": true,
+    "value": null
+  },
+  "serverSideEncryption": {
+    "algorithm": null,
+    "mode": null
+  },
+  "uploadTimestamp": 1653824328881
 }


### PR DESCRIPTION
When calling `upload()` and `listFiles()`, the resulting `File` objects that are created doesn't include all of the available data sent back in the Backblaze response. This behaviour is inconsistent with other methods that create `File` objects from responses (i.e. `copy()`, `getFile()` and `finishLargeFile()`).

This change simply adds the data returned from the response into the already existing properties within the `File` class.