### PR TITLE
Return type to File::jsonSerialize for PHP8.1 deprecation

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -43,7 +43,7 @@ class File implements \JsonSerializable
     /**
      * @return array
      * */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             'id'              => $this->getId(),


### PR DESCRIPTION
Missing return type gives us a deprecation notice as below when running on PHP8.1

`Deprecated: Return type of BackblazeB2\File::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`