### PR TITLE
Compatibility with PHP 8.1

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -43,7 +43,7 @@ class File implements \JsonSerializable
     /**
      * @return array
      * */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize()
     {
         return [
             'id'              => $this->getId(),

--- a/src/File.php
+++ b/src/File.php
@@ -42,7 +42,8 @@ class File implements \JsonSerializable
 
     /**
      * @return array
-     * */
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
Fix for a deprecation warning on PHP 8.1:

> Return type of BackblazeB2\File::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice