### PR TITLE
Added verify_ssl option

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -44,7 +44,7 @@ class Client
         // set reauthorize time to force an authentication to take place
         $this->reAuthTime = Carbon::now('UTC')->subSeconds($this->authTimeoutSeconds * 2);
 
-        $this->client = new HttpClient(['exceptions' => false]);
+        $this->client = new HttpClient(['exceptions' => false, 'verify' => ($options['verify_ssl'] ?? true)]);
         if (isset($options['client'])) {
             $this->client = $options['client'];
         }


### PR DESCRIPTION
- Added the "verify_ssl" option to HTTP requests for certificate verification.
This change is essential for HTTP connections, but it won't impact the behavior of HTTPS requests, by default is true,